### PR TITLE
Make NewRgn & friends work

### DIFF
--- a/extmod/moductypes.c
+++ b/extmod/moductypes.c
@@ -43,7 +43,7 @@
 #define IS_SCALAR_ARRAY_OF_BYTES(tuple_desc) (GET_TYPE(MP_OBJ_SMALL_INT_VALUE((tuple_desc)->items[1]), VAL_TYPE_BITS) == UINT8)
 
 // "struct" in uctypes context means "structural", i.e. aggregate, type.
-static const mp_obj_type_t uctypes_struct_type;
+const mp_obj_type_t uctypes_struct_type;
 
 // Get size of any type descriptor
 static mp_uint_t uctypes_struct_size(mp_obj_t desc_in, int layout_type, mp_uint_t *max_field_size);
@@ -757,7 +757,7 @@ static mp_obj_t uctypes_struct_bytes_at(mp_obj_t ptr, mp_obj_t size) {
 }
 MP_DEFINE_CONST_FUN_OBJ_2(uctypes_struct_bytes_at_obj, uctypes_struct_bytes_at);
 
-static MP_DEFINE_CONST_OBJ_TYPE(
+MP_DEFINE_CONST_OBJ_TYPE(
     uctypes_struct_type,
     MP_QSTR_struct,
     MP_TYPE_FLAG_NONE,

--- a/extmod/moductypes.h
+++ b/extmod/moductypes.h
@@ -30,6 +30,8 @@
 #if MICROPY_PY_UCTYPES
 #include "py/obj.h"
 
+extern const mp_obj_type_t uctypes_struct_type;
+
 typedef struct _mp_obj_ctypes_struct_type_t {
     // This is a mp_obj_type_t with six slots.
     mp_obj_empty_type_t base;

--- a/ports/m68kmac/code.py
+++ b/ports/m68kmac/code.py
@@ -6,9 +6,7 @@ import qd
 import uctypes
 import windowmgr
 
-
-def let(dst, src):
-    memoryview(dst)[:] = memoryview(src)[:]
+scrn = qd.qdGlobals().screenBits
 
 
 def pstr(s):
@@ -26,20 +24,27 @@ ABOVE_ALL_WINDOWS = uctypes.struct(-1, qd.GrafPort)
 
 title = pstr("Hello World")
 r = mactypes.Rect()
-scrn = qd.qdGlobals().screenBits
-let(r, scrn.bounds)
+r[:] = scrn.bounds
 r.top += 80
 qd.InsetRect(r, 25, 25)
 
 w = windowmgr.NewWindow(NIL_WINDOW, r, title, True, 0, ABOVE_ALL_WINDOWS, True, 0)
-let(r, w.portRect)
 qd.SetPort(w)
+r[:] = w.portRect
 
-mid_x = (r.left + r.right) // 2
-mid_y = (r.top + r.bottom) // 2
-for i in range(r.left, r.right, 2):
-    qd.MoveTo(mid_x, r.bottom)
-    qd.LineTo(i, r.top)
 
-qd.MoveTo(mid_x, mid_y)
+g = qd.qdGlobals()
+
+barbell = qd.NewRgn()
+tempRect = mactypes.Rect()
+qd.OpenRgn()
+qd.SetRect(tempRect, 20, 20, 30, 50)
+qd.FrameOval(tempRect)
+qd.SetRect(tempRect, 25, 30, 85, 40)
+qd.FrameRect(tempRect)
+qd.SetRect(tempRect, 80, 20, 90, 50)
+qd.FrameOval(tempRect)
+qd.CloseRgn(barbell)
+qd.FillRgn(barbell, g.black)
+
 input("hit enter to exit")

--- a/ports/m68kmac/multiverse_support.c
+++ b/ports/m68kmac/multiverse_support.c
@@ -16,10 +16,17 @@ void *to_struct_helper(mp_obj_t obj, const mp_obj_type_t *struct_type, bool is_c
     return bufinfo.buf;
 }
 
+static const mp_rom_map_elem_t empty_table[] = {};
+static MP_DEFINE_CONST_DICT(empty_dict, empty_table);
 
 mp_obj_t from_struct_helper(void *buf, const mp_obj_type_t *type) {
-    mp_obj_t args[] = { mp_obj_new_int((mp_uint_t)buf), MP_OBJ_FROM_PTR(type) };
-    return uctypes_struct_make_new(type, 2, 0, args);
+    if (type) {
+        mp_obj_t args[] = { mp_obj_new_int((mp_uint_t)buf), MP_OBJ_FROM_PTR(type) };
+        return uctypes_struct_make_new(type, 2, 0, args);
+    } else {
+        mp_obj_t args[] = { mp_obj_new_int((mp_uint_t)buf), &empty_dict };
+        return uctypes_struct_make_new(&uctypes_struct_type, 2, 0, args);
+    }
 }
 
 void *to_scalar_helper(mp_obj_t obj, size_t objsize, bool is_const) {

--- a/ports/m68kmac/tools/mkapi.py
+++ b/ports/m68kmac/tools/mkapi.py
@@ -273,7 +273,7 @@ class descr_maker_arr_scalar:
     def __call__(self, emitter, offset):
         obj = emitter.common_definition(
             "mp_rom_obj_tuple_t",
-            f"ROM_TUPLE(MP_ROM_INT({offset} | UCTYPE_AGG(ARRAY)), MP_ROM_INT({self.tag} | {self.size}))",
+            f"ROM_TUPLE(MP_ROM_INT({offset} | UCTYPE_AGG(ARRAY)), MP_ROM_INT(UCTYPE_TYPE({self.tag}) | {self.size}))",
         )
         return f"MP_ROM_PTR(&{obj})"
 
@@ -298,7 +298,7 @@ class descr_maker_ptr_scalar:
     def __call__(self, emitter, offset):
         obj = emitter.common_definition(
             "mp_rom_obj_tuple_t",
-            f"ROM_TUPLE(MP_ROM_INT({offset} | UCTYPE_AGG(PTR)), MP_ROM_INT({self.tag}))",
+            f"ROM_TUPLE(MP_ROM_INT({offset} | UCTYPE_AGG(PTR)), MP_ROM_INT(UCTYPE_TYPE({self.tag})))",
         )
         return f"MP_ROM_PTR(&{obj})"
 


### PR DESCRIPTION
Over on Mastodon, Scott reported that NewRgn didn't work.

There are two problems: First, the API translator is treating RgnHandle as an opaque type (which it's not actually). Second, opaque type handling was wrong.

This fixes the 2nd problem, and also a problem with generated tables for describing aggregates of scalars (e.g., pointer-to-char) in non-opaque types.

<img width="1034" height="718" alt="image" src="https://github.com/user-attachments/assets/c0f84e75-449e-4058-a706-0e84fe0bd123" />
