### PR TITLE
Update two examples

### DIFF
--- a/ports/m68kmac/examples/flyingline.py
+++ b/ports/m68kmac/examples/flyingline.py
@@ -64,8 +64,8 @@ def WindowInit():
     newMBarHeight[1] = 0
     menumgr.LMSetMBarHeight(newMBarHeight)
 
-    NIL_WINDOW = uctypes.struct(0, qd.GrafPtr)
-    kMoveToFront = uctypes.struct(-1, qd.GrafPtr)
+    NIL_WINDOW = uctypes.struct(0, qd.GrafPort)
+    kMoveToFront = uctypes.struct(-1, qd.GrafPort)
     kEmptyTitle = pstr("")
     kVisible = True
     kNoGoAway = False

--- a/ports/m68kmac/examples/flyingline.py
+++ b/ports/m68kmac/examples/flyingline.py
@@ -20,7 +20,7 @@ import time
 import toolboxevent
 import uctypes
 import windowmgr
-
+import machine
 
 # Globals
 kNumLines = 50          # Try 100 or 150!
@@ -58,6 +58,7 @@ def WindowInit():
     """
     global gOldMBarHeight
 
+    machine.HideConsole()
     gOldMBarHeight = menumgr.LMGetMBarHeight()
     newMBarHeight = menumgr.LMGetMBarHeight()
     newMBarHeight[1] = 0

--- a/ports/m68kmac/examples/moire.py
+++ b/ports/m68kmac/examples/moire.py
@@ -5,11 +5,8 @@ import mactypes
 import qd
 import uctypes
 import windowmgr
-
-
-def let(dst, src):
-    memoryview(dst)[:] = memoryview(src)[:]
-
+import toolboxevent
+import deskmgr
 
 def pstr(s):
     b = mactypes.Str255()
@@ -27,13 +24,12 @@ ABOVE_ALL_WINDOWS = uctypes.struct(-1, qd.GrafPort)
 title = pstr("Hello World")
 r = mactypes.Rect()
 scrn = qd.qdGlobals().screenBits
-let(r, scrn.bounds)
+r[:] = scrn.bounds
 r.top += 80
 qd.InsetRect(r, 25, 25)
 
-w = windowmgr.NewWindow(NIL_WINDOW, r, title, True, 0, ABOVE_ALL_WINDOWS, False, 0)
-windowmgr.ShowWindow(w)
-let(r, w.portRect)
+w = windowmgr.NewWindow(NIL_WINDOW, r, title, True, 0, ABOVE_ALL_WINDOWS, True, 0)
+r[:] = w.portRect
 qd.SetPort(w)
 
 mid_x = (r.left + r.right) // 2
@@ -42,5 +38,7 @@ for i in range(r.left, r.right, 2):
     qd.MoveTo(mid_x, r.bottom)
     qd.LineTo(i, r.top)
 
-qd.MoveTo(mid_x, mid_y)
-input("hit enter to exit")
+qd.MoveTo(24, 65)
+qd.DrawString(pstr("Click Mouse to Exit"))
+while not toolboxevent.Button():
+    deskmgr.SystemTask()  # scott added - slows it down on fast machines

--- a/ports/m68kmac/examples/region.py
+++ b/ports/m68kmac/examples/region.py
@@ -24,8 +24,8 @@ def pstr(s):
 
 ev = eventmgr.EventRecord()
 
-NIL_WINDOW = uctypes.struct(0, qd.GrafPtr)
-ABOVE_ALL_WINDOWS = uctypes.struct(-1, qd.GrafPtr)
+NIL_WINDOW = uctypes.struct(0, qd.GrafPort)
+ABOVE_ALL_WINDOWS = uctypes.struct(-1, qd.GrafPort)
 
 title = pstr("Region test")
 r = mactypes.Rect()

--- a/ports/m68kmac/examples/region.py
+++ b/ports/m68kmac/examples/region.py
@@ -1,14 +1,18 @@
 # m68k-micropython window creation demo
 
+import deskmgr
 import eventmgr
 import mactypes
 import qd
+import toolboxevent
 import uctypes
 import windowmgr
 import random
+import machine
 
 scrn = qd.qdGlobals().screenBits
 
+machine.HideConsole()
 
 def pstr(s):
     b = mactypes.Str255()
@@ -23,7 +27,7 @@ ev = eventmgr.EventRecord()
 NIL_WINDOW = uctypes.struct(0, qd.GrafPtr)
 ABOVE_ALL_WINDOWS = uctypes.struct(-1, qd.GrafPtr)
 
-title = pstr("Hello World 11")
+title = pstr("Region test")
 r = mactypes.Rect()
 r[:] = scrn.bounds
 r.top += 80
@@ -52,4 +56,9 @@ qd.FillRgn(barbell, g.black)
 
 qd.DisposeRgn(barbell)
 
-input("hit enter to exit")
+qd.MoveTo(24, 65)
+qd.DrawString(pstr("Click Mouse to Exit"))
+
+
+while not toolboxevent.Button():
+    deskmgr.SystemTask()  # scott added - slows it down on fast machines

--- a/ports/m68kmac/examples/region.py
+++ b/ports/m68kmac/examples/region.py
@@ -51,7 +51,6 @@ qd.FrameOval(tempRect)
 qd.CloseRgn(barbell)
 
 r[:] = barbell[0].rgnBBox
-print(f"region size {barbell[0].rgnSize} bbox {r.top},{r.left}..{r.right},{r.bottom}")
 qd.FillRgn(barbell, g.black)
 
 qd.DisposeRgn(barbell)


### PR DESCRIPTION
@smallsco reported that these demos were now crashing. I double checked them in my emulator setup (umac w/system 7) and they were fine for me .. but they needed updating to keep the console window from popping over them.

.. further investigation and seeing crashes on Infinite Mac led me to discover that the problem is an undiagnosed mistake with uctypes structs. Basically, the failing examples specified the special window constants as
```py
    NIL_WINDOW = uctypes.struct(0, qd.GrafPtr)
    kMoveToFront = uctypes.struct(-1, qd.GrafPtr)
```

while the working ones used
```py
    NIL_WINDOW = uctypes.struct(0, qd.GrafPort)
    kMoveToFront = uctypes.struct(-1, qd.GrafPort)
```

(GrafPtr vs GrafPort)

The "wrong" version caused a memory access at 0xffffffff (on all emulators? not sure) which caused a crash on most Ultimate Mac emulations but not in any of the emulators I was using locally.

Here's the distinction as far as I can understand it: The first says "The memory at address 0 (or -1) is a GrafPtr (that is, the 4 bytes that indicate the location of a GrafPort)." and the second says "There is a GrafPort at address 0 (or -1) (that is, the bytes at that address are the device, portBits, and so on)".

Further confusing things, in multiversal, NewWindow's first argument is given as `void *wst` and the later argument is given as `WindowPtr behind`. (`WindowPtr` is just an alias for `GrafPtr`)

Taking the case of `WindowPtr behind`, suppose that Python value passed is `uctypes.struct(-1, qd.GrafPort)`. The actual NewWindow routine in the OS will get the number -1, converted to a pointer. But if it's passed `uctypes.struct(-1, qd.GrafPtr)` then 4 bytes of data starting at address 0xffffffff (-1 converted to a 32-bit unsigned number) are read, *and the value of those bytes (if they can successfully be read)* are what is passed in as the `WindowPtr`.

And that was why the bug popup said the error was in to_struct_helper, reading address 0xffffffff.